### PR TITLE
Update Utica version

### DIFF
--- a/Aliases/utica@0.40
+++ b/Aliases/utica@0.40
@@ -1,0 +1,1 @@
+../Formula/utica.rb

--- a/Formula/utica.rb
+++ b/Formula/utica.rb
@@ -13,6 +13,7 @@ class Utica < Formula
   bottle do
     root_url "https://github.com/Interfere/Utica/releases/download/0.40.1"
     sha256 cellar: :any_skip_relocation, arm64_monterey:                          "2fd2d283c5a2391c5ef0af48924d6aa33222bfebd4b43d3c215104e105840015"
+    sha256 cellar: :any_skip_relocation, monterey:                                "8126368010df2dfcc31411330319a6d1a46019000f326fbb538e779a32e55acd"
   end
 
   def install

--- a/Formula/utica.rb
+++ b/Formula/utica.rb
@@ -1,0 +1,25 @@
+class Utica < Formula
+  desc "Decentralized dependency manager for Cocoa"
+  homepage "https://github.com/Interfere/Utica"
+  url "https://github.com/Interfere/Utica.git",
+      tag:      "0.40.1",
+      revision: "a39075121928d8ad3ecce6fe0d7c895ac361cd1b",
+      shallow:  false
+  license "MIT"
+  head "https://github.com/Interfere/Utica.git", shallow: false
+
+  depends_on xcode: ["12.0", :build]
+
+  def install
+    system "make", "prefix_install", "PREFIX=#{prefix}"
+    bin.install ".build/release/utica"
+    bash_completion.install "Source/Scripts/utica-bash-completion" => "utica"
+    zsh_completion.install "Source/Scripts/utica-zsh-completion" => "_utica"
+    fish_completion.install "Source/Scripts/utica-fish-completion" => "utica.fish"
+  end
+
+  test do
+    (testpath/"Cartfile").write 'github "jspahrsummers/xcconfigs"'
+    system bin/"utica", "update"
+  end
+end

--- a/Formula/utica.rb
+++ b/Formula/utica.rb
@@ -6,7 +6,9 @@ class Utica < Formula
       revision: "a39075121928d8ad3ecce6fe0d7c895ac361cd1b",
       shallow:  false
   license "MIT"
-  head "https://github.com/Interfere/Utica.git", shallow: false
+  head "https://github.com/Interfere/Utica.git",
+      branch:  "master",
+      shallow: false
 
   bottle do
     root_url "https://github.com/Interfere/Utica/releases/download/0.40.1"

--- a/Formula/utica.rb
+++ b/Formula/utica.rb
@@ -10,6 +10,11 @@ class Utica < Formula
 
   depends_on xcode: ["12.0", :build]
 
+  bottle do
+    root_url "https://github.com/Interfere/Utica/releases/download/0.40.1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey:                          "2fd2d283c5a2391c5ef0af48924d6aa33222bfebd4b43d3c215104e105840015"
+  end
+
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}"
     bin.install ".build/release/utica"

--- a/Formula/utica.rb
+++ b/Formula/utica.rb
@@ -8,13 +8,13 @@ class Utica < Formula
   license "MIT"
   head "https://github.com/Interfere/Utica.git", shallow: false
 
-  depends_on xcode: ["12.0", :build]
-
   bottle do
     root_url "https://github.com/Interfere/Utica/releases/download/0.40.1"
     sha256 cellar: :any_skip_relocation, arm64_monterey:                          "2fd2d283c5a2391c5ef0af48924d6aa33222bfebd4b43d3c215104e105840015"
     sha256 cellar: :any_skip_relocation, monterey:                                "8126368010df2dfcc31411330319a6d1a46019000f326fbb538e779a32e55acd"
   end
+
+  depends_on xcode: ["12.0", :build]
 
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}"

--- a/Formula/utica@0.40.0.rb
+++ b/Formula/utica@0.40.0.rb
@@ -10,9 +10,8 @@ class UticaAT0400 < Formula
 
   bottle do
     root_url "https://github.com/Interfere/Utica/releases/download/0.40.0-pre"
-    sha256 cellar: :any_skip_relocation, arm64_monterey:                          "54d91a0b7c4e8006baa28f26780465e199c5e5afca3111eb24f7078f03dbcf3a"
-    sha256 cellar: :any_skip_relocation, big_sur:                                 "6ab9e7afd303018454de648cabe35c8c3bb184b0f6d415abcb2372ac8445b154"
-    sha256 cellar: :any_skip_relocation, catalina:                                "19bdd1b2c96965cc6cb99baa3cc8e53dec77dd28b08b1f2984828e36fcdf383c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey:                          "dc44b4c000e306907996935e2c8a258b8bf2c85eaeb865c0938e880c1ec51a81"
+    sha256 cellar: :any_skip_relocation, monterey:                                "8c113b2808abd09274f4ce21f880fa185dd054551e174e493fce2d94b495b1b4"
   end
 
   depends_on xcode: ["12.0", :build]

--- a/Formula/utica@0.40.0.rb
+++ b/Formula/utica@0.40.0.rb
@@ -6,8 +6,9 @@ class UticaAT0400 < Formula
       revision: "1fc1fba5a4d34117b423d475f594ea433b8efd70",
       shallow:  false
   license "MIT"
-  head "https://github.com/Interfere/Utica.git", shallow: false
-
+  head "https://github.com/Interfere/Utica.git",
+      branch:  "master",
+      shallow: false
   bottle do
     root_url "https://github.com/Interfere/Utica/releases/download/0.40.0-pre"
     sha256 cellar: :any_skip_relocation, arm64_monterey:                          "dc44b4c000e306907996935e2c8a258b8bf2c85eaeb865c0938e880c1ec51a81"

--- a/Formula/utica@0.40.0.rb
+++ b/Formula/utica@0.40.0.rb
@@ -1,4 +1,4 @@
-class Utica < Formula
+class UticaAT0400 < Formula
   desc "Decentralized dependency manager for Cocoa"
   homepage "https://github.com/Interfere/Utica"
   url "https://github.com/Interfere/Utica.git",


### PR DESCRIPTION
This PR is doing the following:
-
- upgrade utica release in the main formula
- have a separate formula for the previous version (utica@0.40.0)
- updating the previous version checksum after changing the formula's name to utica@0.40.0

What is the purpose of this PR:
-
Upgrade utica version and keep the previous version working

-------

- The changes are tested on intel and m1 macbooks and both versions utica & utica@0.40.0 are installed and bottled successfully